### PR TITLE
Support for archiving issue milestone, issue tags, and issue assignee information

### DIFF
--- a/bin/archive
+++ b/bin/archive
@@ -26,6 +26,7 @@ start    = Time.now
 
 # properties to extract from each issue for the archive
 issue_keys = [:title, :number, :state, :html_url, :created_at, :closed_at]
+milestone_keys = [:title, :number, :description, :state]
 
 # Run a git command, piping output to stdout
 def git(*args)
@@ -81,6 +82,7 @@ repos.each do |repo|
     meta = {}
     issue_keys.each { |key| meta[key.to_s] = issue[key] }
     meta["user"] = issue.user.login
+    meta["milestone"] = issue.milestone.to_h.select {|k,v| milestone_keys.include?(k) }.map{ |k, v| {k.to_s => v}}
 
     # Begin to format our output
     output = meta.to_yaml

--- a/bin/archive
+++ b/bin/archive
@@ -82,6 +82,7 @@ repos.each do |repo|
     meta = {}
     issue_keys.each { |key| meta[key.to_s] = issue[key] }
     meta["user"] = issue.user.login
+    meta["tags"] = issue.labels.map {|l| l.name}
     meta["milestone"] = issue.milestone.to_h.select {|k,v| milestone_keys.include?(k) }.map{ |k, v| {k.to_s => v}}
 
     # Begin to format our output

--- a/bin/archive
+++ b/bin/archive
@@ -84,6 +84,7 @@ repos.each do |repo|
     meta["user"] = issue.user.login
     meta["tags"] = issue.labels.map {|l| l.name}
     meta["milestone"] = issue.milestone.to_h.select {|k,v| milestone_keys.include?(k) }.map{ |k, v| {k.to_s => v}}
+    meta["assignee"] = issue.assignee.login
 
     # Begin to format our output
     output = meta.to_yaml


### PR DESCRIPTION
Added support for archiving useful issue milestone, issue tags, and issue assignee information

outputs data in the meta region as:

``` yaml
tags:
- bug
- duplicate
milestone:
- number: 1
- title: Test Milestone
- description: 
- state: open
assignee: StephenOTT
```
