### PR TITLE
Generate timestamp on archive for org + Team Info + Team Repos

### DIFF
--- a/bin/archive
+++ b/bin/archive
@@ -31,6 +31,7 @@ start    = Time.now
 # properties to extract from each issue for the archive
 issue_keys = [:title, :number, :state, :html_url, :created_at, :closed_at]
 milestone_keys = [:title, :number, :description, :state]
+repo_info_keys = [:name, :full_name, :description, :private, :fork, :homepage, :forks_count, :stargazers_count, :watchers_count, :size]
 
 # Run a git command, piping output to stdout
 def git(*args)
@@ -68,6 +69,24 @@ repos.each do |repo|
     logger.info "    Archiving #{repo.name}'s Wiki to #{wiki_dir}"
     `git clone #{wiki_clone_url} #{wiki_dir}`
   end
+
+  # create folder for repo info
+  repo_info_dir = File.expand_path "repo info", repo_dir
+  FileUtils.mkdir(repo_info_dir) unless Dir.exists? repo_info_dir
+
+  # Create path for repo info file.
+  repo_info_path = File.expand_path "repo_info.md", repo_info_dir
+
+  # Get relevant repo info
+  repo_info = repo.to_h.select {|k,v| repo_info_keys.include?(k) }.map{ |k, v| {k.to_s => v}}
+
+  # Begin to format repo info output
+  repo_info_output = "---\n\n"
+  repo_info_output << "# Repo Info\n\n"
+  repo_info_output << repo_info.to_yaml
+
+  # Write repo info to disk
+  File.write repo_info_path, repo_info_output
 
   # Create an issues directory
   issues_dir = File.expand_path "issues", repo_dir

--- a/bin/archive
+++ b/bin/archive
@@ -31,6 +31,9 @@ start    = Time.now
 # properties to extract from each issue for the archive
 issue_keys = [:title, :number, :state, :html_url, :created_at, :closed_at]
 milestone_keys = [:title, :number, :description, :state]
+team_keys = [:name, :slug, :description, :privacy, :permission]
+team_member_keys = [:login, :site_admin, :type]
+team_repo_keys = [:name, :full_name, :permissions]
 repo_info_keys = [:name, :full_name, :description, :private, :fork, :homepage, :forks_count, :stargazers_count, :watchers_count, :size]
 
 # Run a git command, piping output to stdout
@@ -41,6 +44,64 @@ end
 # Init the archive dir
 logger.info "Starting archive for #{org} in #{dest_dir}"
 FileUtils.mkdir_p dest_dir unless Dir.exists? dest_dir
+
+# Pull down Organization Teams and Team Members
+org_teams = client.organization_teams org
+
+# create folder for organizational team information
+teams_dir = File.expand_path "teams", dest_dir
+FileUtils.mkdir(teams_dir) unless Dir.exists? teams_dir
+
+# Loop through each team
+org_teams.each do |team|
+  # Create path for each team file. Use the team slug name to ensure no filesystem issues.
+  team_path = File.expand_path "#{team.slug}.md", teams_dir
+
+  # Pull out relavent team info from team_keys
+  team_info = {}
+  team_keys.each { |key| team_info[key.to_s] = team[key] }
+
+  # Begin to format team output
+  team_output = "---\n\n"
+  team_output << "# Team Info\n\n"
+  team_output << team_info.to_yaml
+
+  # Begin to format team repo output
+  team_output << "---\n\n"
+  team_output << "# Team Repos\n\n"
+
+  # Pull down team repositories
+  team_repos = client.team_repositories team.id
+  team_repos.each do |repo|
+    team_repo_info = {}
+    team_repo_keys.each { |key| team_repo_info[key.to_s] = repo[key] }
+
+    # Repo map permission hash from keys with symbols into strings
+    team_repo_info["permissions"] = team_repo_info["permissions"].map {|k,v| {k.to_s => v}}
+
+    # add team member info to team output
+    team_output << team_repo_info.to_yaml
+  end
+
+  # Begin to format team member output
+  team_output << "---\n\n"
+  team_output << "# Team Members\n\n"
+
+  # Pull down team members for current team
+  team_members = client.team_members team.id
+
+  # Pull out relavent team member info for each team member
+  team_members.each do |member|
+    team_member_info = {}
+    team_member_keys.each { |key| team_member_info[key.to_s] = member[key] }
+
+    # add team member info to team output
+    team_output << team_member_info.to_yaml
+  end
+
+  # Write team info to disk
+  File.write team_path, team_output
+end
 
 # Fetch all organization repositories
 repos = client.organization_repositories org

--- a/bin/archive
+++ b/bin/archive
@@ -19,6 +19,10 @@ Octokit.auto_paginate = true
 token    = ENV["GITHUB_TOKEN"]
 org      = ARGV[0] || ENV["GITHUB_ORGANIZATION"]
 dest_dir = ENV["GITHUB_ARCHIVE_DIR"] || File.expand_path("./archive/#{org}")
+
+# Timestamp each archive of the organization while still allowing custom archive directory in ENV
+dest_dir = "#{dest_dir}/#{Time.new.strftime('%Y%m%dT%H%M%S')}"
+
 client   = Octokit::Client.new :access_token => token
 logger   = Logger.new(STDOUT)
 pwd      = Dir.pwd


### PR DESCRIPTION
Generates a timestamp: `%Y%m%dT%H%M%S` = 20160109T152503 for each
archive of the organization.  Every time a archive is actioned it will
generate a new folder inside of the organization folder with the
timestamp.  This supports the ENV archive location as well.  The timestamp will be added to whichever ENV location or the default archive location.

Example:
![screen shot 2016-01-09 at 3 33 56 pm](https://cloud.githubusercontent.com/assets/1994838/12218199/aa261b76-b6e6-11e5-8cb9-192e35397184.png)

Possible future updates: Make this an optional command that is activated through parameters in the CLI

Additionally there are commits for the following:
- Repo info is captured and stored in `repo info > repo info.md` (https://github.com/StephenOTT/github-records-archiver/commit/274ad2d0725b49b64459844b1160ff4e5aa74c56)
- Organization Teams are captures as well as their useful info + the Repos that are assigned to each team and the repo's useful info. (https://github.com/StephenOTT/github-records-archiver/commit/6fc121615e1167fd15e0431069329e494e9cbc1d)
