### PR TITLE
Update README to match actual command name

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,12 +27,12 @@ gem install github_records_archiver
 ## Basic usage
 
 ```shell
-$ github_records_archiver archive ORGANIZATION --token PERSONAL_ACCESS_TOKEN`
+$ github-records-archiver archive ORGANIZATION --token PERSONAL_ACCESS_TOKEN`
 ```
 Alternatively, you could pass the personal access token as the `GITHUB_TOKEN` environmental variable:
 
 ```shell
-$ GITHUB_TOKEN=1234 github_records_archiver archive ORGANIZATION`
+$ GITHUB_TOKEN=1234 github-records-archiver archive ORGANIZATION`
 ```
 
 ## Output


### PR DESCRIPTION
The README appears to have an out-of-date command name, probably related to the switch to Thor.

<img width="1001" alt="image" src="https://user-images.githubusercontent.com/4215/39883629-736abfba-5455-11e8-87b9-c337a5b87eb7.png">

This pull request updates the README to use the `github-records-archiver` command, as it exists in [`/bin`](https://github.com/benbalter/github_records_archiver/blob/master/bin/github-records-archiver)


